### PR TITLE
fix challenge 002

### DIFF
--- a/challenges/002.md
+++ b/challenges/002.md
@@ -100,7 +100,7 @@ git checkout tags/<version> -b mynode
 In the `nearcore` folder run the following commands:
 
 ```
-make neard
+cargo build -p neard --release --features shardnet
 ```
 The binary path is `target/release/neard`. If you are seeing issues, it is possible that cargo command is not found. Make sure `sudo apt install cargo`. Compiling `nearcore` binary may take a little while.
 


### PR DESCRIPTION
We need to use `--features shardnet` to build neard and cannot do `make neard` directly because we need to enable the chunk only producer feature (right now it exists as a nightly feature)