### PR TITLE
Specify python version

### DIFF
--- a/challenges/002.md
+++ b/challenges/002.md
@@ -40,7 +40,7 @@ lscpu | grep -P '(?=.*avx )(?=.*sse4.2 )(?=.*cx16 )(?=.*popcnt )' > /dev/null \
 
 ##### Install developer tools:
 ```
-sudo apt install -y git binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev cmake gcc g++ python docker.io protobuf-compiler libssl-dev pkg-config clang llvm cargo
+sudo apt install -y git binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev cmake gcc g++ python3 docker.io protobuf-compiler libssl-dev pkg-config clang llvm cargo
 ```
 #####  Install Python pip:
 


### PR DESCRIPTION
Specify python version to avoid this error:
```E: Package 'python' has no installation candidate```