### PR TITLE
Update 006.md (Change /home/<USER_ID> to $HOME)

### DIFF
--- a/challenges/006.md
+++ b/challenges/006.md
@@ -27,6 +27,19 @@ near validators current | grep $POOLID >> $LOGS/all.log
 near validators next | grep $POOLID >> $LOGS/all.log
 
 ```
+
+Create logs folder:
+
+```
+mkdir $HOME/logs
+```
+
+Change execute permission for ping.sh file:
+
+```
+chmod +x $HOME/scripts/ping.sh
+```
+
 Create a new crontab, running every 2 hours:
 
 ```

--- a/challenges/006.md
+++ b/challenges/006.md
@@ -42,7 +42,7 @@ crontab -l
 Review your logs 
 
 ```
-cat /home/<USER_ID>/logs/all.log
+cat $HOME/logs/all.log
 ```
 
 ## Acceptance criteria:


### PR DESCRIPTION
Change /home/<USER_ID> to $HOME, using the $HOME variable will make it more convenient, users can directly copy the command and paste it without editing. Moreover, there are machines using the root account, the root directory will be at /root/, so using /home/ is not suitable for everyone.